### PR TITLE
enhancement(toolchain version): README.md - updating minimun required Rust version (1.65+ -> 1.71.1+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is an alternative implementation of [rust-libp2p](https://github.com/libp2p
 
 To build this project you need the following:
 
-- Rust 1.65+
+- Rust 1.71.1+
 - [Buf CLI](https://docs.buf.build/installation)
 - [Protobuf Compiler (protoc)](https://grpc.io/docs/protoc-installation/)
 - [Protoc prost plugins (protoc-gen-prost)](https://github.com/neoeinstein/protoc-gen-prost):

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is an alternative implementation of [rust-libp2p](https://github.com/libp2p
 
 To build this project you need the following:
 
-- Rust 1.71.1+
+- Rust toolchain. The required version is automatically enforced by the _rust-toolchain.toml_ file.
 - [Buf CLI](https://docs.buf.build/installation)
 - [Protobuf Compiler (protoc)](https://grpc.io/docs/protoc-installation/)
 - [Protoc prost plugins (protoc-gen-prost)](https://github.com/neoeinstein/protoc-gen-prost):

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+# The default profile includes rustc, rust-std, cargo, rust-docs, rustfmt and clippy.
+# https://rust-lang.github.io/rustup/concepts/profiles.html
+profile = "default"
+channel = "1.71.1"


### PR DESCRIPTION
A simple change in the `README.md` so that we indicate the minimum required rust version.

This version is to prevent the next compilation error:

![Screenshot from 2023-08-17 17-30-51](https://github.com/LNSD/rust-libp2p-pubsub/assets/53038020/f71c56be-41da-42e8-b85a-a8ad2c836395)
